### PR TITLE
Avoid TypeError when textarea is empty.

### DIFF
--- a/jquery.textcomplete.js
+++ b/jquery.textcomplete.js
@@ -302,7 +302,6 @@
         // span element into the textarea.
         // Consequently, the span element's position is the thing what we want.
 
-        if (this.el.selectionEnd === 0) return;
         var properties, css, $div, $span, position, dir;
 
         dir = this.$el.attr('dir') || this.$el.css('direction');


### PR DESCRIPTION
Avoid returning undefined from getCaretPosition, so that we don't
pass undefined to jQuery.css.

Fixes #53.
