### PR TITLE
Add support for Emacs-style prev/next keybindings.

### DIFF
--- a/jquery.textcomplete.js
+++ b/jquery.textcomplete.js
@@ -230,8 +230,13 @@
           return true;
         }
         switch (e.keyCode) {
-          case 40:
-          case 38:
+          case 40: // DOWN
+          case 38: // UP
+            return true;
+        }
+        if (e.ctrlKey) switch (e.keyCode) {
+          case 78: // Ctrl-N
+          case 80: // Ctrl-P
             return true;
         }
       },
@@ -468,7 +473,7 @@
 
       onKeydown: function (e) {
         if (!this.shown) return;
-        if (e.keyCode === 38) {         // UP
+        if (e.keyCode === 38 || (e.ctrlKey && e.keyCode === 80)) {         // UP, or Ctrl-P
           e.preventDefault();
           if (this.index === 0) {
             this.index = this.data.length-1;
@@ -476,7 +481,7 @@
             this.index -= 1;
           }
           this.activateIndexedItem();
-        } else if (e.keyCode === 40) {  // DOWN
+        } else if (e.keyCode === 40 || (e.ctrlKey && e.keyCode === 78)) {  // DOWN, or Ctrl-N
           e.preventDefault();
           if (this.index === this.data.length - 1) {
             this.index = 0;


### PR DESCRIPTION
Among other places that support Ctrl-P and Ctrl-N for "prev" and
"next" line movement, Mac OS X supports this systemwide, so it's
nice to recognize them like arrow keys in jquery-textcomplete.
