### PR TITLE
CSS property copying: border-style and box-sizing

### DIFF
--- a/jquery.textcomplete.js
+++ b/jquery.textcomplete.js
@@ -334,7 +334,7 @@
           'word-spacing', 'line-height', 'text-decoration', 'text-align',
           'width', 'padding-top', 'padding-right', 'padding-bottom',
           'padding-left', 'margin-top', 'margin-right', 'margin-bottom',
-          'margin-left'
+          'margin-left', 'border-style', 'box-sizing'
         ];
         scrollbar = this.$el[0].scrollHeight > this.$el[0].offsetHeight;
         css = $.extend({


### PR DESCRIPTION
Copying the CSS property "border-width" has no effect unless "border-style" is copied, too (at least in Google Chrome).

Additionally, the CSS property "box-sizing" affects the layout and should be copied, too.
