### PR TITLE
fixing bug where user cannot click the dropdown to autocomplete

### DIFF
--- a/jquery.textcomplete.js
+++ b/jquery.textcomplete.js
@@ -453,7 +453,7 @@
       this.index = 0;
       this.completer = completer;
 
-      this.$el.on('click.textComplete', 'li.textcomplete-item',
+      this.$el.on('mousedown.textComplete', 'li.textcomplete-item',
                   $.proxy(this.onClick, this));
     }
 
@@ -584,6 +584,7 @@
 
       onClick: function (e) {
         var $e = $(e.target);
+        e.preventDefault();
         e.originalEvent.keepTextCompleteDropdown = true;
         if (!$e.hasClass('textcomplete-item')) {
           $e = $e.parents('li.textcomplete-item');


### PR DESCRIPTION
Steps to reproduce bug:

1) navigate to index.html
2) scroll down to the contenteditable example
3) type "st" into the contenteditable
4) instead of hitting enter, click "stunning" with your mouse
5) it does not work if you click the dropdown menu with your mouse

this pull request fixes that

http://stackoverflow.com/questions/7392959/how-do-you-avoid-losing-focus-on-a-contenteditable-element-when-a-user-clicks-ou
