### PR TITLE
Select should only replace the matched text.

### DIFF
--- a/jquery.textcomplete.js
+++ b/jquery.textcomplete.js
@@ -256,7 +256,7 @@
       },
 
       onSelect: function (value) {
-        var pre, post, newSubStr, sel, range, selection;
+        var pre, post, newSubStr, sel, range, selection, match;
         pre = this.getTextFromHeadToCaret();
 
         if (this.el.contentEditable == 'true') {
@@ -269,7 +269,7 @@
         } else {
           post = this.el.value.substring(this.el.selectionEnd);
         }
-
+        
         newSubStr = this.strategy.replace(value);
         
         if ($.isArray(newSubStr)) {
@@ -277,7 +277,9 @@
           newSubStr = newSubStr[0];
         }
 
-        pre = pre.replace(this.strategy.match, newSubStr);
+        match = pre.match(this.strategy.match);
+		
+        pre = pre.replace(match[this.strategy.index], newSubStr);
         
         if (this.el.contentEditable == 'true') {
           range.selectNodeContents(range.startContainer);


### PR DESCRIPTION
When using multiple capturing groups and the index parameter often times the non-capturing groups/groups outside of the specified index get consumed. This fixes that.
