### PR TITLE
option to supply list view position function

### DIFF
--- a/jquery.textcomplete.js
+++ b/jquery.textcomplete.js
@@ -457,6 +457,9 @@
       this.$el = $el;
       this.index = 0;
       this.completer = completer;
+      if (completer.option.listPosition) {
+        this.setPosition = completer.option.listPosition;
+      }
 
       this.$el.on('mousedown.textComplete', 'li.textcomplete-item',
                   $.proxy(this.onClick, this));


### PR DESCRIPTION
I had a use case where I needed to position the list myself instead of following the cursor. My textarea was pretty small (in a narrow column) and near the bottom edge of the window and I wanted the list to display in a specific position.

I'm hoping you'll see that this is a simple but useful change to consider.

Usage example:

``` js
$('textarea').textcomplete([
  { // emoji strategy
    match: /(^|\s):(\w*)$/,
    search: function (term, callback) {
      var regexp = new RegExp('^' + term);
      callback($.grep(emojies, function (emoji) {
        return regexp.test(emoji);
      }));
    },
    replace: function (value) {
      return '$1:' + value + ': ';
    }
  }
], {
  listPosition: function (position) {
    this.$el.css({
      top: 'auto',
      bottom: 50,
      left: 0
    });
    return this;
  }
});
```

And if you think there's a better way to implement this, I'm happy to update this PR. :+1: 
