### PR TITLE
fix horizonal position on contentEditable elements

### DIFF
--- a/jquery.textcomplete.js
+++ b/jquery.textcomplete.js
@@ -392,6 +392,7 @@
           range.deleteContents();
           $node = $(node);
           position = $node.offset();
+          position.left -= this.$el.offset().left;
           position.top += $node.height() - this.$el.offset().top;
         }
         dir = this.$el.attr('dir') || this.$el.css('direction');


### PR DESCRIPTION
The dropdown currently appears too far to the right because getCaretRelativePosition isn't adjusting the left property to make it relative to its parent.

This bug is visible on your demo page: http://yuku-t.com/jquery-textcomplete/

This PR adjusts the left position to correct the issue.
