### PR TITLE
Fixes the fire function for events with additional parameters

### DIFF
--- a/src/completer.js
+++ b/src/completer.js
@@ -160,7 +160,7 @@
       this.$el.trigger(eventName, args);
       return this;
     },
-    
+
     register: function (strategies) {
       Array.prototype.push.apply(this.strategies, strategies);
     },


### PR DESCRIPTION
It's mentioned in the docs that the 'textcomplete:select' event fires off `value` and `strategy` as well as the `event`, but only the `event` was getting through. This fix will allow the `fire` method to emit those additional parameters.
