### PR TITLE
Support element.contentEditable compatibility check

### DIFF
--- a/src/completer.js
+++ b/src/completer.js
@@ -18,7 +18,7 @@
   //   lockedFunc();  // none
   //   lockedFunc();  // none
   //   // 1 sec past then
-  //   // => 'Hello, world' 
+  //   // => 'Hello, world'
   //   lockedFunc();  // => 'Hello, world'
   //   lockedFunc();  // none
   //
@@ -70,8 +70,8 @@
     this.views      = [];
     this.option     = $.extend({}, Completer._getDefaults(), option);
 
-    if (!this.$el.is('textarea') && !element.isContentEditable) {
-      throw new Error('textcomplete must be called to a Textarea or a ContentEditable.');
+    if (!this.$el.is('textarea') && !element.isContentEditable && element.contentEditable != 'true') {
+      throw new Error('textcomplete must be called on a Textarea or a ContentEditable.');
     }
 
     if (element === document.activeElement) {

--- a/src/main.js
+++ b/src/main.js
@@ -40,7 +40,7 @@ if (typeof jQuery === 'undefined') {
           $.each(['header', 'footer', 'placement', 'maxCount'], function (name) {
             if (obj[name]) {
               completer.option[name] = obj[name];
-              warn(name + 'as a strategy param is deplicated. Use option.');
+              warn(name + 'as a strategy param is deprecated. Use option.');
               delete obj[name];
             }
           });


### PR DESCRIPTION
Not all browsers support `isContentEditable`, some support `contentEditable` and return 'true' if the element is content editable.  This adds additional support.

I also fixed a couple of typos that I saw.

For more information see:
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement.contentEditable
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement.isContentEditable
