### PR TITLE
Fix #299: ignore search callback after dropdown deactivate

### DIFF
--- a/src/completer.js
+++ b/src/completer.js
@@ -236,23 +236,26 @@
           if (match) { return [strategy, match[strategy.index], match]; }
         }
       }
-      return []
+      return [];
     },
 
-    // Call the search method of selected strategy..
+    // Call the search method of selected strategy.
     _search: lock(function (free, strategy, term, match) {
       var self = this;
+      var thisSearchId = self.dropdown.newActivationId();
       strategy.search(term, function (data, stillSearching) {
-        if (!self.dropdown.shown) {
-          self.dropdown.activate();
+        if (!self.dropdown.cancelledActivationId(thisSearchId)) {
+          if (!self.dropdown.shown) {
+            self.dropdown.activate();
+          }
+          if (self._clearAtNext) {
+            // The first callback in the current lock.
+            self.dropdown.clear();
+            self._clearAtNext = false;
+          }
+          self.dropdown.setPosition(self.adapter.getCaretPosition());
+          self.dropdown.render(self._zip(data, strategy, term));
         }
-        if (self._clearAtNext) {
-          // The first callback in the current lock.
-          self.dropdown.clear();
-          self._clearAtNext = false;
-        }
-        self.dropdown.setPosition(self.adapter.getCaretPosition());
-        self.dropdown.render(self._zip(data, strategy, term));
         if (!stillSearching) {
           // The last callback in the current lock.
           free();

--- a/src/content_editable.js
+++ b/src/content_editable.js
@@ -89,6 +89,10 @@
       range.deleteContents();
       var $node = $(node);
       var position = $node.offset();
+      if (position.width === 0) {
+         // jQuery returned us the raw browser ClientRect object; avoid writing to it
+         position = { left: position.left, top: position.top };
+      }
       position.left -= this.$el.offset().left;
       position.top += $node.height() - this.$el.offset().top;
       position.lineHeight = $node.height();

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -98,6 +98,11 @@
     data:      [],     // Shown zipped data.
     className: '',
 
+    // Private properties
+    // ------------------
+    _activationId: 0,
+    _cancelledActivationId: 0,
+
     // Public methods
     // --------------
 
@@ -168,6 +173,14 @@
       this._$header = this._$footer = this._$noResultsMessage = null;
     },
 
+    newActivationId: function () {
+      return ++this._activationId;
+    },
+
+    cancelledActivationId: function (activationId) {
+      return this._cancelledActivationId >= activationId;
+    },
+
     activate: function () {
       if (!this.shown) {
         this.clear();
@@ -186,6 +199,7 @@
         this.completer.fire('textComplete:hide');
         this.shown = false;
       }
+      this._cancelledActivationId = this._activationId;
       return this;
     },
 


### PR DESCRIPTION
2 separate fixes here for the case where you manage to type faster than the network/server/etc can complete the request to supply the search callback with data, and you trigger textcomplete, then backspace over the trigger, and then a late call to the search callback happens:

1) keep track of the last time a search was initiated, and the last time the dropdown was deactivated, and ignore calls to the search callback that are for a search which has already been cancelled

2) detect a case that's problematic in (at least) webkit based browsers when using textcomplete on contenteditable elements, where the caret is in a placeholder div with no other contents, and when we go to calculate the caret position, the offset rect has 0 width and height, tricking jQuery into feeding us a nonwritable version of the ClientRect object.