### PR TITLE
Don't let contextFunc influence other strategies

### DIFF
--- a/src/completer.js
+++ b/src/completer.js
@@ -231,8 +231,8 @@
         var context = strategy.context(text);
         if (context || context === '') {
           var matchRegexp = $.isFunction(strategy.match) ? strategy.match(text) : strategy.match;
-          if (isString(context)) { text = context; }
-          var match = text.match(matchRegexp);
+          if (!isString(context)) { context = text; }
+          var match = context.match(matchRegexp);
           if (match) { return [strategy, match[strategy.index], match]; }
         }
       }


### PR DESCRIPTION
This fixes issue #301.
Using contextFunc in one strategy should have no effect on other strategies.
But before this change, the contextFunc would replace the text passed to the remaining strategies also.
Instead now only the current strategy uses the context directly (or the original text if the strategy uses no context function). The text is not changed anymore.