### PR TITLE
Scroll dropdown to active item if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 
 ## [Unreleased]
 
+## 2018-10-10
+### Added
+- When dropdown has scrollbar applied, scroll position will follow active item
+
 ## [0.17.1] - 2018-03-31
 ### Fixed
 - Fix placement of dropdown menu in textarea with no line-height set.

--- a/src/dropdown_item.js
+++ b/src/dropdown_item.js
@@ -17,6 +17,7 @@ interface Dropdown {
   rotate: ?Boolean;
   getActiveItem(): DropdownItem | null;
   select(DropdownItem): DropdownItem;
+  el: HTMLUListElement;
 }
 
 /**
@@ -98,6 +99,9 @@ export default class DropdownItem {
       this.dropdown.activeItem = this
       this.active = true
       this.el.className = this.activeClassName
+
+      const offsetToScroll = this.el.offsetTop
+      this.dropdown.el.scrollTop = offsetToScroll
     }
     return this
   }


### PR DESCRIPTION
If dropdown has limited size (like with max-height css property), this will allow users to always see their selected value as dropdown content will scroll with active item