### PR TITLE
Fix for cross-domain iframe access exception.

### DIFF
--- a/src/completer.js
+++ b/src/completer.js
@@ -137,11 +137,15 @@
       // we need to alter positioning logic if using an iframe
       if (this.$el.prop('ownerDocument') !== document && window.frames.length) {
         for (var iframeIndex = 0; iframeIndex < window.frames.length; iframeIndex++) {
-          if (this.$el.prop('ownerDocument') === window.frames[iframeIndex].document) {
-            this.$iframe = $(window.frames[iframeIndex].frameElement);
-            break;
-          }
-        }
+	  try {
+            if (this.$el.prop('ownerDocument') === window.frames[iframeIndex].document) {
+              this.$iframe = $(window.frames[iframeIndex].frameElement);
+              break;
+            }
+	  } catch(e) {
+	      // skip any cross-domain access exceptions.
+	  }
+	}
       }
       
       


### PR DESCRIPTION
When CORS is not enabled for iframe cross-domain exception happens, this better be skipped.