### PR TITLE
feat(dropdown): add parent property for element to append options to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 
 ## [Unreleased]
 
+## 2019-07-31
+### Added
+- Add parent property to `DropDownOptions` to enable specifying the element to append the drop down items to
+
 ## 2018-10-10
 ### Added
 - Add 'auto' placement feature

--- a/doc/api.md
+++ b/doc/api.md
@@ -132,7 +132,7 @@ Returns **[DropdownItem](#dropdownitem)?**
 
 ## DropdownOptions
 
-Type: {className: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?, footer: function (any): ([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))?, header: function (any): ([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))?, maxCount: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?, placement: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?, rotate: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?, style: {}?, item: [DropdownItemOptions](#dropdownitemoptions)?}
+Type: {className: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?, footer: function (any): ([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))?, header: function (any): ([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))?, maxCount: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?, placement: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?, rotate: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?, style: {}?, item: [DropdownItemOptions](#dropdownitemoptions)?, parent: [HtmlElement](https://developer.mozilla.org/docs/Web/API/HTMLElement)?}
 
 **Properties**
 
@@ -144,6 +144,7 @@ Type: {className: [string](https://developer.mozilla.org/docs/Web/JavaScript/Ref
 -   `rotate` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** 
 -   `style` **{}?** 
 -   `item` **[DropdownItemOptions](#dropdownitemoptions)?** 
+-   `parent` **[HtmlElement](https://developer.mozilla.org/docs/Web/API/HTMLElement)?** 
 
 ## Dropdown
 

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -18,6 +18,7 @@ export type DropdownOptions = {
   rotate?: boolean,
   style?: { [string]: string },
   item?: DropdownItemOptions,
+  parent?: HTMLElement,
 }
 
 /**
@@ -36,23 +37,29 @@ export default class Dropdown extends EventEmitter {
   rotate: $PropertyType<DropdownOptions, "rotate">
   placement: $PropertyType<DropdownOptions, "placement">
   itemOptions: DropdownItemOptions
+  _parent: HTMLElement
   _el: ?HTMLUListElement
 
-  static createElement(): HTMLUListElement {
+  static createElement(parent?: HTMLElement): HTMLUListElement {
     const el = document.createElement("ul")
     const style = el.style
     style.display = "none"
     style.position = "absolute"
     style.zIndex = "10000"
-    const body = document.body
-    if (body) {
-      body.appendChild(el)
+    if (parent) {
+      parent.appendChild(el);
+    } else {
+      const body = document.body
+      if (body) {
+        body.appendChild(el)
+      }
     }
     return el
   }
 
   constructor(options: DropdownOptions) {
     super()
+    this._parent = options.parent
     this.shown = false
     this.items = []
     this.activeItem = null
@@ -79,13 +86,14 @@ export default class Dropdown extends EventEmitter {
     if (parentNode) {
       parentNode.removeChild(this.el)
     }
+    this._parent = null
     this.clear()._el = null
     return this
   }
 
   get el(): HTMLUListElement {
     if (!this._el) {
-      this._el = Dropdown.createElement()
+      this._el = Dropdown.createElement(this._parent)
     }
     return this._el
   }


### PR DESCRIPTION
When using the text complete within an HTML5 dialog element, it is not possible to set the z-index such that the dropdown results are rendered over the dialog. This adds the ability to specify the parent element for which the dropdown results should be appended to.