### PR TITLE
Fix peerDependencies

### DIFF
--- a/packages/textcomplete-codemirror/package.json
+++ b/packages/textcomplete-codemirror/package.json
@@ -30,7 +30,7 @@
     "typescript": "^3.9.5"
   },
   "peerDependencies": {
-    "@textcomplete/core": "^0.0.0",
+    "@textcomplete/core": "^0.1.2",
     "codemirror": "^5.54"
   },
   "publishConfig": {

--- a/packages/textcomplete-contenteditable/package.json
+++ b/packages/textcomplete-contenteditable/package.json
@@ -29,7 +29,7 @@
     "typescript": "^3.9.5"
   },
   "peerDependencies": {
-    "@textcomplete/core": "^0.0.0"
+    "@textcomplete/core": "^0.1.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/textcomplete-textarea/package.json
+++ b/packages/textcomplete-textarea/package.json
@@ -23,7 +23,7 @@
     "undate": "^0.3.0"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.0.0",
+    "@textcomplete/core": "^0.1.2",
     "@typescript-eslint/eslint-plugin": "^3.2.0",
     "@typescript-eslint/parser": "^3.2.0",
     "eslint": "^7.2.0",
@@ -33,7 +33,7 @@
     "typescript": "^3.9.5"
   },
   "peerDependencies": {
-    "@textcomplete/core": "^0.0.0"
+    "@textcomplete/core": "^0.1.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
The following dependency errors have been fixed.

```
├─┬ UNMET PEER DEPENDENCY @textcomplete/core@0.1.2
│ └── eventemitter3@4.0.4
└─┬ @textcomplete/textarea@0.1.2
  ├── UNMET PEER DEPENDENCY @textcomplete/core@0.1.2 deduped
  ├── @textcomplete/utils@0.1.2
  ├── @types/textarea-caret@3.0.0
  ├── textarea-caret@3.1.0
  └── undate@0.3.0

npm ERR! peer dep missing: @textcomplete/core@^0.0.0, required by @textcomplete/textarea@0.1.2
npm ERR! peer dep missing: @textcomplete/core@^0.0.0, required by @textcomplete/textarea@0.1.2
```