### PR TITLE
Fix StrategyProps interface

### DIFF
--- a/packages/textcomplete-core/src/Strategy.ts
+++ b/packages/textcomplete-core/src/Strategy.ts
@@ -3,7 +3,8 @@ import { SearchResult } from "./SearchResult"
 export type SearchCallback<T> = (results: T[]) => void
 type ReplaceResult = [string, string] | string | null
 
-export interface StrategyProps<T = unknown> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface StrategyProps<T = any> {
   match: RegExp | ((regexp: string | RegExp) => RegExpMatchArray | null)
   search: (
     term: string,


### PR DESCRIPTION
If the default value of generics is unknown, the problem is as follows.

https://www.typescriptlang.org/play?#code/C4TwDgpgBAyhCGAnAxgCwMLwDZYEb2QGsAeAFQD4oBeKACkQgGcBXLYRgLilIG0BdAJTVKANwD2ASwAmAKFCQoAJQhgsBCMpZtqUHo2CIJAOwDmAGij7DpvlAA+lg8ZP2oR1lhkzjwCIgBm6rAG8L4mIAAKiGJgjGQ6zEaERmIA7kaUAN4yUFAAtqFoXMomAKIAHmCutPQQJhCVXFbOriUVYEJUlG2VALKFqACCiIjwIK7uOAI5lggoqFy0M7m+iHlNTqZmy1DI2HgEhFxwSGiYOPhEZOTbubkFwEVKde39j0MjYzOdopKyuQxVOpFlJQvAuKQfs8gcgNExWMAZns0BAAPxcXBiMRYBBGJFiIy+crAdF0InADbWExQ5qmVyY7G4ma+PJA3yk2ig4Dg7gWVbrRxUmmbEwzYxSBqk9x5XB+MVSUm00UAXy8yAJ+kFzhgITCIGOurqkWisWISsoNGyd3yA0WUMmWFud0YcyetF88DyFj2F0OUMSEv8xggUidAJUalhILBUIA5LHtqqZOqjJrpbLEDrRnqDdmjVEYnF034LVArXcHm77R4w7NTgsyQgvbt9pdCP6jIHg6GdoDIxBo9y4wmZEmU5qrKE6hImLmp+EC7F+Do9CKs-OQBZi5nDeE+EA

Specifically, the following code will cause an TS2322 error.

```typescript
const stringStrategy: StrategyProps<string> = {
    match: () => null,
    search: (team, callback) => undefined,
    replace: (data) => '',
}

const textcomplete = new Textcomplete(editor, [stringStrategy], option)
```