### PR TITLE
Option for specifying a dynamic width

### DIFF
--- a/packages/textcomplete-core/src/Dropdown.ts
+++ b/packages/textcomplete-core/src/Dropdown.ts
@@ -14,6 +14,7 @@ export interface DropdownOption {
   rotate?: boolean
   style?: CSSStyleDeclaration
   parent?: HTMLElement
+	dynamicWidth?: boolean
 }
 
 interface DropdownItemOption {
@@ -204,7 +205,7 @@ export class Dropdown extends EventEmitter {
     if (doc) {
       const elementWidth = this.el.offsetWidth
       if (cursorOffset.left) {
-        const browserWidth = doc.clientWidth
+        const browserWidth = this.options.dynamicWidth ? doc.scrollWidth : doc.clientWidth
         if (cursorOffset.left + elementWidth > browserWidth) {
           cursorOffset.left = browserWidth - elementWidth
         }


### PR DESCRIPTION
Goal:
The goal of this PR is to provide users with an option to specify that their UI features a dynamic width.

Reason for change:
The application I am building expands the width of the document element dynamically. As a result, the anchor point of the dropdown stays at the window width's edge instead of expanding rightward. 

Since the `clientWidth` of the document is computed initially and never again, it isn't ideal for applications whose UI expands. Instead, `scrollWidth` works better. This PR adds an option for specifying a need for this value.