### PR TITLE
Handle highlight with mouse events only

### DIFF
--- a/packages/textcomplete-core/src/Dropdown.ts
+++ b/packages/textcomplete-core/src/Dropdown.ts
@@ -78,7 +78,7 @@ export class Dropdown extends EventEmitter {
     this.items = searchResults
       .slice(0, this.option.maxCount || DEFAULT_DROPDOWN_MAX_COUNT)
       .map(
-        (r, index) => new DropdownItem(this, index, r, this.option?.item || {})
+        (r, index) => new DropdownItem(this, index, r, this.option?.item || {}, this.activate.bind(this, index))
       )
     this.setStrategyId(searchResults[0])
       .renderEdge(searchResults, "header")
@@ -183,13 +183,16 @@ export class Dropdown extends EventEmitter {
 
   activate(index: number): this {
     if (this.activeIndex !== index) {
-      if (this.activeIndex != null) {
-        this.items[this.activeIndex].deactivate()
-      }
-      this.activeIndex = index
-      this.items[index].activate()
+      this.deactivateAll();
+      this.activeIndex = index;
+      this.items[index].activate();
     }
     return this
+  }
+
+  deactivateAll(): this {
+    this.items.forEach((i) => i.deactivate());
+    return this;
   }
 
   isShown(): boolean {
@@ -302,7 +305,8 @@ class DropdownItem {
     private readonly dropdown: Dropdown,
     private readonly index: number,
     public readonly searchResult: SearchResult<unknown>,
-    private readonly props: DropdownItemOption
+    private readonly props: DropdownItemOption,
+    private readonly activationHandler: any
   ) {
     this.className = this.props.className || DEFAULT_DROPDOWN_ITEM_CLASS_NAME
     this.activeClassName =
@@ -316,8 +320,9 @@ class DropdownItem {
     span.innerHTML = this.searchResult.render()
     li.appendChild(span)
 
-    li.addEventListener("mousedown", this.onClick)
-    li.addEventListener("touchstart", this.onClick)
+    li.addEventListener("mousedown", this.onClick);
+    li.addEventListener("touchstart", this.onClick);
+    li.addEventListener("mouseenter", activationHandler);
 
     this.el = li
   }

--- a/packages/textcomplete-core/src/Dropdown.ts
+++ b/packages/textcomplete-core/src/Dropdown.ts
@@ -78,7 +78,14 @@ export class Dropdown extends EventEmitter {
     this.items = searchResults
       .slice(0, this.option.maxCount || DEFAULT_DROPDOWN_MAX_COUNT)
       .map(
-        (r, index) => new DropdownItem(this, index, r, this.option?.item || {}, this.activate.bind(this, index))
+        (r, index) =>
+          new DropdownItem(
+            this,
+            index,
+            r,
+            this.option?.item || {},
+            this.activate.bind(this, index)
+          )
       )
     this.setStrategyId(searchResults[0])
       .renderEdge(searchResults, "header")
@@ -183,16 +190,16 @@ export class Dropdown extends EventEmitter {
 
   activate(index: number): this {
     if (this.activeIndex !== index) {
-      this.deactivateAll();
-      this.activeIndex = index;
-      this.items[index].activate();
+      this.deactivateAll()
+      this.activeIndex = index
+      this.items[index].activate()
     }
     return this
   }
 
   deactivateAll(): this {
-    this.items.forEach((i) => i.deactivate());
-    return this;
+    this.items.forEach((i) => i.deactivate())
+    return this
   }
 
   isShown(): boolean {
@@ -320,9 +327,9 @@ class DropdownItem {
     span.innerHTML = this.searchResult.render()
     li.appendChild(span)
 
-    li.addEventListener("mousedown", this.onClick);
-    li.addEventListener("touchstart", this.onClick);
-    li.addEventListener("mouseenter", activationHandler);
+    li.addEventListener("mousedown", this.onClick)
+    li.addEventListener("touchstart", this.onClick)
+    li.addEventListener("mouseenter", activationHandler)
 
     this.el = li
   }


### PR DESCRIPTION
Goal:
The goal of this PR is to use javascript mouse events to highlight active elements in the emoji dropdown.

Summary:
Right now, the first item of the emoji dropdown stays highlighted even when selecting other elements. The reason for that is that the current logic does not deactivate the first element when the dropdown is first shown. This PR deactivates all elements on every mouse movement.

![mouseonly](https://user-images.githubusercontent.com/3819564/92955457-021cf280-f41a-11ea-901c-7c1bf8f22faf.gif)
