### PR TITLE
Fix breaking tests and upgrade devDependencies

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -9,7 +9,7 @@ plugins:
 extends:
   - 'plugin:@typescript-eslint/recommended'
   - 'plugin:prettier/recommended'
-  - 'prettier/@typescript-eslint'
+  - 'prettier'
 rules:
   '@typescript-eslint/no-unused-vars':
     - 'error'

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,19 +21,20 @@
     "react-dom": "^16.13.1"
   },
   "devDependencies": {
-    "@types/react": "^16.9.36",
-    "@types/react-dom": "^16.9.8",
-    "@typescript-eslint/eslint-plugin": "^3.2.0",
-    "@typescript-eslint/parser": "^3.2.0",
-    "eslint": "^7.2.0",
-    "eslint-config-prettier": "^6.11.0",
+    "@types/react": "^17.0.3",
+    "@types/react-dom": "^17.0.2",
+    "@typescript-eslint/eslint-plugin": "^4.17.0",
+    "@typescript-eslint/parser": "^4.17.0",
+    "eslint": "^7.21.0",
+    "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^4.0.4",
+    "lerna": "^4.0.0",
     "parcel-bundler": "^1.12.4",
     "prettier": "^2.0.5",
-    "pug": "^3.0.0",
-    "sass": "^1.26.8"
+    "pug": "^3.0.2",
+    "sass": "^1.32.8"
   },
   "prettier": {
     "semi": false

--- a/docs/package.json
+++ b/docs/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^4.0.4",
     "lerna": "^4.0.0",
-    "parcel-bundler": "^1.12.4",
+    "parcel-bundler": "1.12.3",
     "prettier": "^2.0.5",
     "pug": "^3.0.2",
     "sass": "^1.32.8"

--- a/packages/textcomplete-codemirror/package.json
+++ b/packages/textcomplete-codemirror/package.json
@@ -20,14 +20,14 @@
   },
   "devDependencies": {
     "@textcomplete/core": "^0.1.9",
-    "@typescript-eslint/eslint-plugin": "^3.2.0",
-    "@typescript-eslint/parser": "^3.2.0",
-    "codemirror": "^5.54",
-    "eslint": "^7.2.0",
-    "eslint-config-prettier": "^6.11.0",
+    "@typescript-eslint/eslint-plugin": "^4.17.0",
+    "@typescript-eslint/parser": "^4.17.0",
+    "codemirror": "^5.59.4",
+    "eslint": "^7.21.0",
+    "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "prettier": "^2.0.5",
-    "typescript": "^3.9.5"
+    "typescript": "^4.2.3"
   },
   "peerDependencies": {
     "@textcomplete/core": "^0.1.3",

--- a/packages/textcomplete-codemirror/package.json
+++ b/packages/textcomplete-codemirror/package.json
@@ -30,7 +30,7 @@
     "typescript": "^4.2.3"
   },
   "peerDependencies": {
-    "@textcomplete/core": "^0.1.3",
+    "@textcomplete/core": "^0.1.9",
     "codemirror": "^5.54"
   },
   "publishConfig": {

--- a/packages/textcomplete-contenteditable/package.json
+++ b/packages/textcomplete-contenteditable/package.json
@@ -29,7 +29,7 @@
     "typescript": "^4.2.3"
   },
   "peerDependencies": {
-    "@textcomplete/core": "^0.1.3"
+    "@textcomplete/core": "^0.1.9"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/textcomplete-contenteditable/package.json
+++ b/packages/textcomplete-contenteditable/package.json
@@ -20,13 +20,13 @@
   },
   "devDependencies": {
     "@textcomplete/core": "^0.1.9",
-    "@typescript-eslint/eslint-plugin": "^3.2.0",
-    "@typescript-eslint/parser": "^3.2.0",
-    "eslint": "^7.2.0",
-    "eslint-config-prettier": "^6.11.0",
+    "@typescript-eslint/eslint-plugin": "^4.17.0",
+    "@typescript-eslint/parser": "^4.17.0",
+    "eslint": "^7.21.0",
+    "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "prettier": "^2.0.5",
-    "typescript": "^3.9.5"
+    "typescript": "^4.2.3"
   },
   "peerDependencies": {
     "@textcomplete/core": "^0.1.3"

--- a/packages/textcomplete-core/package.json
+++ b/packages/textcomplete-core/package.json
@@ -21,15 +21,15 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.0",
-    "@typescript-eslint/eslint-plugin": "^3.2.0",
-    "@typescript-eslint/parser": "^3.2.0",
-    "eslint": "^7.2.0",
-    "eslint-config-prettier": "^6.11.0",
+    "@typescript-eslint/eslint-plugin": "^4.17.0",
+    "@typescript-eslint/parser": "^4.17.0",
+    "eslint": "^7.21.0",
+    "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "jest": "^26.0.1",
     "prettier": "^2.0.5",
-    "ts-jest": "^26.1.0",
-    "typescript": "^3.9.5"
+    "ts-jest": "^26.5.3",
+    "typescript": "^4.2.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/textcomplete-core/src/Dropdown.ts
+++ b/packages/textcomplete-core/src/Dropdown.ts
@@ -36,7 +36,7 @@ export class Dropdown extends EventEmitter {
   private items: DropdownItem[] = []
   private activeIndex: number | null = null
 
-  static create<T>(option: DropdownOption): Dropdown {
+  static create(option: DropdownOption): Dropdown {
     const ul = document.createElement("ul")
     ul.className = option.className || DEFAULT_DROPDOWN_CLASS_NAME
     Object.assign(

--- a/packages/textcomplete-textarea/package.json
+++ b/packages/textcomplete-textarea/package.json
@@ -16,14 +16,13 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "dependencies": {
-    "@textcomplete/core": "^0.1.9",
     "@textcomplete/utils": "^0.1.9",
     "@types/textarea-caret": "^3.0.0",
     "textarea-caret": "^3.1.0",
     "undate": "^0.3.0"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.3",
+    "@textcomplete/core": "^0.1.9",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",
     "eslint": "^7.21.0",
@@ -33,7 +32,7 @@
     "typescript": "^4.2.3"
   },
   "peerDependencies": {
-    "@textcomplete/core": "^0.1.3"
+    "@textcomplete/core": "^0.1.9"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/textcomplete-textarea/package.json
+++ b/packages/textcomplete-textarea/package.json
@@ -24,13 +24,13 @@
   },
   "devDependencies": {
     "@textcomplete/core": "^0.1.3",
-    "@typescript-eslint/eslint-plugin": "^3.2.0",
-    "@typescript-eslint/parser": "^3.2.0",
-    "eslint": "^7.2.0",
-    "eslint-config-prettier": "^6.11.0",
+    "@typescript-eslint/eslint-plugin": "^4.17.0",
+    "@typescript-eslint/parser": "^4.17.0",
+    "eslint": "^7.21.0",
+    "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "prettier": "^2.0.5",
-    "typescript": "^3.9.5"
+    "typescript": "^4.2.3"
   },
   "peerDependencies": {
     "@textcomplete/core": "^0.1.3"

--- a/packages/textcomplete-utils/package.json
+++ b/packages/textcomplete-utils/package.json
@@ -17,13 +17,13 @@
   },
   "devDependencies": {
     "@textcomplete/core": "^0.1.9",
-    "@typescript-eslint/eslint-plugin": "^3.2.0",
-    "@typescript-eslint/parser": "^3.2.0",
-    "eslint": "^7.2.0",
-    "eslint-config-prettier": "^6.11.0",
+    "@typescript-eslint/eslint-plugin": "^4.17.0",
+    "@typescript-eslint/parser": "^4.17.0",
+    "eslint": "^7.21.0",
+    "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "prettier": "^2.0.5",
-    "typescript": "^3.9.5"
+    "typescript": "^4.2.3"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## What
* Upgrade all devDependencies except for parcel-bundler
* Downgrade parcel-bundler to 1.12.3 (workaround for https://github.com/parcel-bundler/parcel/issues/5943)
* Fix .eslint (due to changes in [eslint-config-prettier@8.0.0](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21))
* Fix lint error
* Update internal dependency versions