### PR TITLE
Replace only needed range in CodeMirror

### DIFF
--- a/packages/textcomplete-codemirror/src/CodeMirrorEditor.ts
+++ b/packages/textcomplete-codemirror/src/CodeMirrorEditor.ts
@@ -18,14 +18,19 @@ export class CodeMirrorEditor extends Editor {
    * @implements {@link Editor#applySearchResult}
    */
   applySearchResult(searchResult: SearchResult): void {
-    const replace = searchResult.replace(
-      this.getBeforeCursor(),
-      this.getAfterCursor()
-    )
-    if (Array.isArray(replace)) {
-      this.cm.setValue(replace[0] + replace[1])
-      const lines = replace[0].split("\n")
-      this.cm.setCursor(lines.length - 1, lines[lines.length - 1].length)
+    const replacement = searchResult.getReplacementData(this.getBeforeCursor())
+    if (replacement) {
+      this.cm.replaceRange(
+        replacement.beforeCursor + replacement.afterCursor,
+        this.cm.posFromIndex(replacement.start),
+        this.cm.posFromIndex(replacement.end)
+      )
+
+      this.cm.setCursor(
+        this.cm.posFromIndex(
+          replacement.start + replacement.beforeCursor.length
+        )
+      )
     }
     this.cm.focus()
   }

--- a/packages/textcomplete-core/src/SearchResult.ts
+++ b/packages/textcomplete-core/src/SearchResult.ts
@@ -10,23 +10,46 @@ export class SearchResult<T = unknown> {
     private readonly strategy: Strategy<T>
   ) {}
 
-  replace(beforeCursor: string, afterCursor: string): [string, string] | void {
+  getReplacementData(beforeCursor: string): {
+    start: number
+    end: number
+    beforeCursor: string
+    afterCursor: string
+  } | null {
     let result = this.strategy.replace(this.data)
-    if (result == null) return
+    if (result == null) return null
+
+    let afterCursor = ""
     if (Array.isArray(result)) {
-      afterCursor = result[1] + afterCursor
+      afterCursor = result[1]
       result = result[0]
     }
     const match = this.strategy.match(beforeCursor)
-    if (match == null || match.index == null) return
+    if (match == null || match.index == null) return null
     const replacement = result
       .replace(MAIN, match[0])
       .replace(PLACE, (_, p) => match[parseInt(p)])
+
+    return {
+      start: match.index,
+      end: match.index + match[0].length,
+      beforeCursor: replacement,
+      afterCursor: afterCursor,
+    }
+  }
+
+  replace(beforeCursor: string, afterCursor: string): [string, string] | void {
+    const replacement = this.getReplacementData(beforeCursor)
+
+    if (replacement === null) return
+
+    afterCursor = replacement.afterCursor + afterCursor
+
     return [
       [
-        beforeCursor.slice(0, match.index),
-        replacement,
-        beforeCursor.slice(match.index + match[0].length),
+        beforeCursor.slice(0, replacement.start),
+        replacement.beforeCursor,
+        beforeCursor.slice(replacement.end),
       ].join(""),
       afterCursor,
     ]


### PR DESCRIPTION
For https://github.com/yuku/textcomplete/issues/346

- Added a method to `SearchResult` class to provide replacement data.
- Using the above method, replace only needed range in CodeMirror.
- In order not to change the interface of the `SearchResult#replace`, the information needed for replacement can be obtained with getReplacementData, which is used in `SearchResult#replace` and `@textcomplete/codemirror`.