### PR TITLE
Use click event

### DIFF
--- a/packages/textcomplete-core/src/Dropdown.ts
+++ b/packages/textcomplete-core/src/Dropdown.ts
@@ -316,8 +316,7 @@ class DropdownItem {
     span.innerHTML = this.searchResult.render()
     li.appendChild(span)
 
-    li.addEventListener("mousedown", this.onClick)
-    li.addEventListener("touchstart", this.onClick)
+    li.addEventListener("click", this.onClick)
 
     this.el = li
   }
@@ -325,8 +324,7 @@ class DropdownItem {
   destroy(): this {
     const li = this.el
     li.parentNode?.removeChild(li)
-    li.removeEventListener("mousedown", this.onClick, false)
-    li.removeEventListener("touchstart", this.onClick, false)
+    li.removeEventListener("click", this.onClick, false)
     return this
   }
 


### PR DESCRIPTION
If a Dropdown element is scrollable, an attempt to scroll it from a touch devise will trigger the `touchstart` event.
I don't think it would be a problem to change it to a `click` event, but what do you think?