### PR TITLE
Dependencies upgrade

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -16,3 +16,4 @@ rules:
     - ignoreRestSiblings: true
       argsIgnorePattern: '^_'
   '@typescript-eslint/no-explicit-any': 'error'
+  'prettier/prettier': 'error'

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 packages/jquery-textcomplete/dist/* linguist-vendored
 packages/jquery-textcomplete/src/vendor/* linguist-vendored
+
+* text=auto eol=lf

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -6,8 +6,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install --no-lockfile

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -9,9 +9,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 18.x
       - run: yarn install --no-lockfile
-      - run: yarn lerna bootstrap
       - run: yarn build
       - uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,8 +8,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,10 +11,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org
       - run: yarn install --no-lockfile
-      - run: yarn lerna bootstrap
       - run: yarn build:packages
       - run: yarn lerna publish from-git --yes --no-push --no-git-tag-version
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,9 +10,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 18.x
       - run: yarn install
-      - run: yarn lerna bootstrap
       - run: yarn build
       - run: yarn lint
       - run: yarn test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,8 +7,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ yarn.lock
 package-lock.json
 .vscode/*
 !.vscode/textcomplete.code-workspace
+.idea
 docs/.cache
 lerna-debug.log

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+trailingComma: 'es5'
+semi: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Textcomplete
 
-> Autocomplete for HTMLTextAreaElement and more.
+Autocomplete for HTMLTextAreaElement and more.
 
 ![Publish](https://github.com/yuku/textcomplete/workflows/Publish/badge.svg)
 ![Test](https://github.com/yuku/textcomplete/workflows/Test/badge.svg)
@@ -8,27 +8,26 @@
 
 ![](./docs/images/demo.gif)
 
-[Document](https://yuku.takahashi.coffee/textcomplete/).
+See more at [yuku.takahashi.coffee/textcomplete](https://yuku.takahashi.coffee/textcomplete/)
 
 ## Packages
 
 Textcomplete consists of subpackages:
 
-Name                          | Description
-------------------------------|-------------------------------------------
-@textcomplete/core            | Core of Textcomplete.
-@textcomplete/textarea        | Editor for HTMLTextAreaElement.
-@textcomplete/contenteditable | Editor for contenteditable. (Experimental)
-@textcomplete/codemirror      | Editor for CodeMirror. (Experimental)
-@textcomplete/utils           | Utility functions for editors.
+| Name                          | Description                                |
+|-------------------------------|--------------------------------------------|
+| @textcomplete/core            | Core of Textcomplete.                      |
+| @textcomplete/textarea        | Editor for HTMLTextAreaElement.            |
+| @textcomplete/contenteditable | Editor for contenteditable. (Experimental) |
+| @textcomplete/codemirror      | Editor for CodeMirror. (Experimental)      |
+| @textcomplete/utils           | Utility functions for editors.             |
 
 ## Development
 
-### View Document
+### View documentation
 
 ```bash
 yarn install
-yarn lerna bootstrap
 yarn docs
 ```
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,11 +3,11 @@
   "private": true,
   "version": "0.1.12",
   "scripts": {
-    "build": "rm -fr dist .cache && parcel build index.pug --public-url /textcomplete",
-    "format:eslint": "eslint --fix '**/*.ts' '**/*.tsx'",
-    "format:prettier": "prettier --write '**/*.ts' '**/*.tsx'",
+    "build": "rimraf dist .cache && parcel build index.pug --public-url /textcomplete",
+    "format:eslint": "eslint --fix **/*.ts **/*.tsx",
+    "format:prettier": "prettier --write **/*.ts **/*.tsx",
     "format": "run-s format:eslint format:prettier",
-    "lint": "eslint '**/*.ts' '**/*.tsx'",
+    "lint": "eslint **/*.ts **/*.tsx",
     "start": "parcel index.pug"
   },
   "dependencies": {
@@ -23,9 +23,9 @@
   "devDependencies": {
     "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.2",
-    "eslint": "^7.21.0",
-    "eslint-plugin-react": "^7.20.0",
-    "eslint-plugin-react-hooks": "^4.0.4",
+    "eslint": "^8.55.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "parcel-bundler": "1.12.5",
     "pug": "^3.0.2",
     "sass": "^1.32.8"

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.12",
   "scripts": {
-    "build": "rm -fr dist cache && parcel build index.pug --public-url /textcomplete",
+    "build": "rm -fr dist .cache && parcel build index.pug --public-url /textcomplete",
     "format:eslint": "eslint --fix '**/*.ts' '**/*.tsx'",
     "format:prettier": "prettier --write '**/*.ts' '**/*.tsx'",
     "format": "run-s format:eslint format:prettier",
@@ -11,10 +11,10 @@
     "start": "parcel index.pug"
   },
   "dependencies": {
-    "@textcomplete/codemirror": "^0.1.11",
+    "@textcomplete/codemirror": "^0.1.12",
     "@textcomplete/contenteditable": "^0.1.12",
-    "@textcomplete/core": "^0.1.11",
-    "@textcomplete/textarea": "^0.1.11",
+    "@textcomplete/core": "^0.1.12",
+    "@textcomplete/textarea": "^0.1.12",
     "codemirror": "^5.54.0",
     "prism-react-renderer": "^1.1.1",
     "react": "^17.0.2",

--- a/docs/sections/Editors.tsx
+++ b/docs/sections/Editors.tsx
@@ -62,7 +62,7 @@ export const Editors: FC<Props> = ({ id }) => (
       />
     </section>
     <section>
-      <h2>Contenteditable</h2>
+      <h2 id="textcomplete-contenteditable">Contenteditable</h2>
       <p>
         <code>@textcomplete/contenteditable</code> provides a textcomplete
         editor implementation for a contenteditable element. This package is

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,6 @@
 {
   "version": "0.1.12",
   "npmClient": "yarn",
-  "useWorkspaces": true,
   "command": {
     "version": {
       "ignoreChanges": [
@@ -14,5 +13,6 @@
   "packages": [
     "packages/textcomplete-*",
     "docs"
-  ]
+  ],
+  "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package.json
+++ b/package.json
@@ -16,18 +16,18 @@
     "test": "lerna run test --parallel"
   },
   "devDependencies": {
-    "@types/jest": "^27.0.1",
+    "@types/jest": "^29.5.10",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",
     "eslint": "^7.21.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "jest": "^27.2.0",
-    "lerna": "^3.22.1",
+    "jest": "^29.7.0",
+    "lerna": "^8.0.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
-    "ts-jest": "^27.0.5",
-    "typescript": "^4.4.3"
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.3.2"
   },
   "prettier": {
     "semi": false

--- a/package.json
+++ b/package.json
@@ -17,19 +17,18 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.10",
-    "@typescript-eslint/eslint-plugin": "^4.17.0",
-    "@typescript-eslint/parser": "^4.17.0",
-    "eslint": "^7.21.0",
-    "eslint-config-prettier": "^8.1.0",
-    "eslint-plugin-prettier": "^4.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.13.2",
+    "@typescript-eslint/parser": "^6.13.2",
+    "eslint": "^8.55.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.0.1",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "~29.7.0",
     "lerna": "^8.0.0",
+    "rimraf": "^5.0.5",
     "npm-run-all": "^4.1.5",
-    "prettier": "^2.0.5",
+    "prettier": "^3.1.0",
     "ts-jest": "^29.1.1",
     "typescript": "^5.3.2"
-  },
-  "prettier": {
-    "semi": false
   }
 }

--- a/packages/textcomplete-codemirror/README.md
+++ b/packages/textcomplete-codemirror/README.md
@@ -1,8 +1,10 @@
 # @textcomplete/codemirror
 
-> Textcomplete editor for CodeMirror. (Experimental)
+Textcomplete editor for CodeMirror. (Experimental)
 
 [![npm version](https://badge.fury.io/js/@textcomplete%2Fcodemirror.svg)](http://badge.fury.io/js/@textcomplete%2Fcodemirror)
+
+Check the live demo [here](https://yuku.takahashi.coffee/textcomplete/#textcomplete-codemirror).
 
 ## Install
 

--- a/packages/textcomplete-codemirror/package.json
+++ b/packages/textcomplete-codemirror/package.json
@@ -9,11 +9,11 @@
   "author": "Yuku Takahashi",
   "license": "MIT",
   "scripts": {
-    "build": "rm -fr dist && tsc",
-    "format:eslint": "eslint --fix 'src/**/*.ts'",
-    "format:prettier": "prettier --write 'src/**/*.ts'",
+    "build": "rimraf dist && tsc",
+    "format:eslint": "eslint --fix src/**/*.ts",
+    "format:prettier": "prettier --write src/**/*.ts",
     "format": "run-s format:eslint format:prettier",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint src/**/*.ts"
   },
   "devDependencies": {
     "@textcomplete/core": "^0.1.12",

--- a/packages/textcomplete-codemirror/package.json
+++ b/packages/textcomplete-codemirror/package.json
@@ -16,12 +16,12 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.11",
+    "@textcomplete/core": "^0.1.12",
     "@types/codemirror": "^5.60.2",
     "codemirror": "^5.54"
   },
   "peerDependencies": {
-    "@textcomplete/core": "^0.1.9",
+    "@textcomplete/core": "^0.1.12",
     "codemirror": "^5.54"
   },
   "publishConfig": {

--- a/packages/textcomplete-contenteditable/README.md
+++ b/packages/textcomplete-contenteditable/README.md
@@ -1,9 +1,10 @@
 # @textcomplete/contenteditable
 
-> Textcomplete editor for contenteditable. (Experimental)
+Textcomplete editor for contenteditable. (Experimental)
 
 [![npm version](https://badge.fury.io/js/@textcomplete%2Fcontenteditable.svg)](http://badge.fury.io/js/@textcomplete%2Fcontenteditable)
 
+Check the live demo [here](https://yuku.takahashi.coffee/textcomplete/#textcomplete-contenteditable).
 
 ## Install
 

--- a/packages/textcomplete-contenteditable/package.json
+++ b/packages/textcomplete-contenteditable/package.json
@@ -9,11 +9,11 @@
   "author": "Yuku Takahashi",
   "license": "MIT",
   "scripts": {
-    "build": "rm -fr dist && tsc",
-    "format:eslint": "eslint --fix 'src/**/*.ts'",
-    "format:prettier": "prettier --write 'src/**/*.ts'",
+    "build": "rimraf dist && tsc",
+    "format:eslint": "eslint --fix src/**/*.ts",
+    "format:prettier": "prettier --write src/**/*.ts",
     "format": "run-s format:eslint format:prettier",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint src/**/*.ts"
   },
   "dependencies": {
     "@textcomplete/utils": "^0.1.12"

--- a/packages/textcomplete-contenteditable/package.json
+++ b/packages/textcomplete-contenteditable/package.json
@@ -16,13 +16,13 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "dependencies": {
-    "@textcomplete/utils": "^0.1.11"
+    "@textcomplete/utils": "^0.1.12"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.11"
+    "@textcomplete/core": "^0.1.12"
   },
   "peerDependencies": {
-    "@textcomplete/core": "^0.1.9"
+    "@textcomplete/core": "^0.1.12"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/textcomplete-core/README.md
+++ b/packages/textcomplete-core/README.md
@@ -1,8 +1,10 @@
 # @textcomplete/core
 
-> Core of Textcomplete
+Core of Textcomplete
 
 [![npm version](https://badge.fury.io/js/@textcomplete%2Fcore.svg)](http://badge.fury.io/js/@textcomplete%2Fcore)
+
+Read more and check the live demo at [yuku.takahashi.coffee/textcomplete](https://yuku.takahashi.coffee/textcomplete/)
 
 ## License
 

--- a/packages/textcomplete-core/package.json
+++ b/packages/textcomplete-core/package.json
@@ -9,11 +9,11 @@
   "author": "Yuku Takahashi",
   "license": "MIT",
   "scripts": {
-    "build": "rm -fr dist && tsc",
-    "format:eslint": "eslint --fix 'src/**/*.ts'",
-    "format:prettier": "prettier --write 'src/**/*.ts'",
+    "build": "rimraf dist && tsc",
+    "format:eslint": "eslint --fix src/**/*.ts",
+    "format:prettier": "prettier --write src/**/*.ts",
     "format": "run-s format:eslint format:prettier",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint src/**/*.ts",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/textcomplete-core/package.json
+++ b/packages/textcomplete-core/package.json
@@ -17,7 +17,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "eventemitter3": "^4.0.4"
+    "eventemitter3": "^5.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/textcomplete-core/src/Dropdown.ts
+++ b/packages/textcomplete-core/src/Dropdown.ts
@@ -248,8 +248,8 @@ export class Dropdown extends EventEmitter {
     return this.activeIndex < this.items.length - 1
       ? this.activeIndex + 1
       : this.option.rotate
-      ? 0
-      : null
+        ? 0
+        : null
   }
 
   private getPrevActiveIndex(): number | null {
@@ -257,8 +257,8 @@ export class Dropdown extends EventEmitter {
     return this.activeIndex !== 0
       ? this.activeIndex - 1
       : this.option.rotate
-      ? this.items.length - 1
-      : null
+        ? this.items.length - 1
+        : null
   }
 
   private renderItems(): this {

--- a/packages/textcomplete-core/src/Editor.ts
+++ b/packages/textcomplete-core/src/Editor.ts
@@ -109,20 +109,23 @@ export abstract class Editor extends EventEmitter {
    * @see {@link Textarea} for live example.
    */
   protected getCode(e: KeyboardEvent): KeyCode {
-    return e.keyCode === 9 // tab
-      ? "ENTER"
-      : e.keyCode === 13 // enter
-      ? "ENTER"
-      : e.keyCode === 27 // esc
-      ? "ESC"
-      : e.keyCode === 38 // up
-      ? "UP"
-      : e.keyCode === 40 // down
-      ? "DOWN"
-      : e.keyCode === 78 && e.ctrlKey // ctrl-n
-      ? "DOWN"
-      : e.keyCode === 80 && e.ctrlKey // ctrl-p
-      ? "UP"
-      : "OTHER"
+    switch (e.keyCode) {
+      case 9: // tab
+      case 13: // enter
+        return "ENTER"
+      case 27: // esc
+        return "ESC"
+      case 38: // up
+        return "UP"
+      case 40: // down
+        return "DOWN"
+      case 78: // ctrl-n
+        if (e.ctrlKey) return "DOWN"
+        break
+      case 80: // ctrl-p
+        if (e.ctrlKey) return "UP"
+        break
+    }
+    return "OTHER"
   }
 }

--- a/packages/textcomplete-textarea/README.md
+++ b/packages/textcomplete-textarea/README.md
@@ -1,8 +1,10 @@
 # @textcomplete/textarea
 
-> Textcomplete editor for HTMLTextAreaElement.
+Textcomplete editor for HTMLTextAreaElement.
 
 [![npm version](https://badge.fury.io/js/@textcomplete%2Ftextarea.svg)](http://badge.fury.io/js/@textcomplete%2Ftextarea)
+
+Check the live demo [here](https://yuku.takahashi.coffee/textcomplete/#textcomplete-textarea).
 
 ## Install
 

--- a/packages/textcomplete-textarea/package.json
+++ b/packages/textcomplete-textarea/package.json
@@ -9,11 +9,11 @@
   "author": "Yuku Takahashi",
   "license": "MIT",
   "scripts": {
-    "build": "rm -fr dist && tsc",
-    "format:eslint": "eslint --fix 'src/**/*.ts'",
-    "format:prettier": "prettier --write 'src/**/*.ts'",
+    "build": "rimraf dist && tsc",
+    "format:eslint": "eslint --fix src/**/*.ts",
+    "format:prettier": "prettier --write src/**/*.ts",
     "format": "run-s format:eslint format:prettier",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint src/**/*.ts"
   },
   "dependencies": {
     "@textcomplete/utils": "^0.1.12",

--- a/packages/textcomplete-textarea/package.json
+++ b/packages/textcomplete-textarea/package.json
@@ -16,16 +16,16 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "dependencies": {
-    "@textcomplete/utils": "^0.1.11",
+    "@textcomplete/utils": "^0.1.12",
     "textarea-caret": "^3.1.0",
     "undate": "^0.3.0"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.11",
-    "@types/textarea-caret": "^3.0.0"
+    "@textcomplete/core": "^0.1.12",
+    "@types/textarea-caret": "^3.0.3"
   },
   "peerDependencies": {
-    "@textcomplete/core": "^0.1.9"
+    "@textcomplete/core": "^0.1.12"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/textcomplete-utils/README.md
+++ b/packages/textcomplete-utils/README.md
@@ -1,8 +1,10 @@
 # @textcomplete/utils
 
-> Utility functions for Textcomplete editors.
+Utility functions for Textcomplete editors.
 
 [![npm version](https://badge.fury.io/js/@textcomplete%2Futils.svg)](http://badge.fury.io/js/@textcomplete%2Futils)
+
+Read more at [yuku.takahashi.coffee/textcomplete](https://yuku.takahashi.coffee/textcomplete/)
 
 ## License
 

--- a/packages/textcomplete-utils/package.json
+++ b/packages/textcomplete-utils/package.json
@@ -9,26 +9,16 @@
   "author": "Yuku Takahashi",
   "license": "MIT",
   "scripts": {
-    "build": "rm -fr dist && tsc",
-    "format:eslint": "eslint --fix 'src/**/*.ts'",
-    "format:prettier": "prettier --write 'src/**/*.ts'",
+    "build": "rimraf dist && tsc",
+    "format:eslint": "eslint --fix src/**/*.ts",
+    "format:prettier": "prettier --write src/**/*.ts",
     "format": "run-s format:eslint format:prettier",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint src/**/*.ts"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.12",
-    "@typescript-eslint/eslint-plugin": "^4.17.0",
-    "@typescript-eslint/parser": "^4.17.0",
-    "eslint": "^7.21.0",
-    "eslint-config-prettier": "^8.1.0",
-    "eslint-plugin-prettier": "^4.0.0",
-    "prettier": "^2.0.5",
-    "typescript": "^5.3.2"
+    "@textcomplete/core": "^0.1.12"
   },
   "publishConfig": {
     "access": "public"
-  },
-  "prettier": {
-    "semi": false
   }
 }

--- a/packages/textcomplete-utils/package.json
+++ b/packages/textcomplete-utils/package.json
@@ -16,14 +16,14 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.11",
+    "@textcomplete/core": "^0.1.12",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",
     "eslint": "^7.21.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.0.5",
-    "typescript": "^4.2.3"
+    "typescript": "^5.3.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Upgrades the dependencies, adds an extra docs link to all README files to make the NPM package descriptions more user-friendly.

- `lerna bootstrap` is no longer necessary as per https://lerna.js.org/docs/legacy-package-management#migrating-from-lerna-bootstrap-lerna-add-and-lerna-link-in-lerna-v7-and-later
- `* text=auto eol=lf` forces `LF` on every platform so that prettier won't fail on `CRLF` on Windows
- `rimraf` provides a cross platform replacement for `rm -fr`