### PR TITLE
Fix: Prevent duplicate input event after applying search result

### DIFF
--- a/packages/textcomplete-textarea/src/TextareaEditor.ts
+++ b/packages/textcomplete-textarea/src/TextareaEditor.ts
@@ -30,9 +30,6 @@ export class TextareaEditor extends Editor {
       this.el.focus() // Clicking a dropdown item removes focus from the element.
       if (Array.isArray(replace)) {
         update(this.el, replace[0], replace[1])
-        if (this.el) {
-          this.el.dispatchEvent(createCustomEvent("input"))
-        }
       }
     }
   }


### PR DESCRIPTION
When selecting an autocomplete suggestion (e.g., after typing #), the Textcomplete plugin triggers the context() and search() functions twice instead of once. This results in unexpected double workflow cycles.

## Root Cause

In @textcomplete/textarea, the applySearchResult function internally uses the [update](https://github.com/yuku/undate) package to update the text content. The update function already dispatches a native input event after applying the change.
```js
 if (!document.execCommand("insertText", false, strB2)) {
    // Document.execCommand returns false if the command is not supported.
    // Firefox and IE returns false in this case.
    el.value = next

    // Dispatch input event. Note that `new Event("input")` throws an error on IE11
    const event = document.createEvent("Event")
    event.initEvent("input", true, true)
    el.dispatchEvent(event)
 }
  ```
However, immediately after that, applySearchResult dispatches another input event manually:

```js
 if (Array.isArray(replace)) {
    update(this.el, replace[0], replace[1])
    if (this.el) {
      this.el.dispatchEvent(createCustomEvent("input"))
    }
 }
```
This results in two input events for a single action — triggering duplicate plugin workflows.

## Fix

Commented out the redundant input event dispatch in applySearchResult. This avoids firing duplicate input events and ensures only one workflow/search cycle is triggered after selecting a suggestion.

## Verified

- Confirmed with logging: now only a single workflow is started after selecting an autocomplete item.
- Behavior matches expectation — no adverse side effects observed.


## Related
Fixes behavior demonstrated in this bug report:
 [Double workflow/search triggered after selection in strategy matching (version 0.1.13)](https://github.com/yuku/textcomplete/issues/363)
